### PR TITLE
fix for rtx 30xx gpus

### DIFF
--- a/_int8_fwd.py
+++ b/_int8_fwd.py
@@ -9,7 +9,10 @@ nothing.
 import torch
 import triton
 import triton.language as tl
-from triton.tools.tensor_descriptor import TensorDescriptor
+try:
+    from triton.tools.tensor_descriptor import TensorDescriptor
+except ModuleNotFoundError:
+    TensorDescriptor = None
 
 from ._fused_prep import fused_preprocess
 from ._tri_fwd import _has_tma
@@ -316,6 +319,8 @@ def sol_attn_int8(q, k, v, *, scale=None, tau=1.0, sink_blocks=(0, 0), sink_q=(0
     if use_tma:
         q, k, v = q.contiguous(), k.contiguous(), v.contiguous()
         q, k, v, tokens, padded = _pad_to_blocks(q, k, v, BLOCK)
+        if TensorDescriptor is None:
+            raise RuntimeError("TensorDescriptor is unavailable for the TMA path.")
     else:
         # Pointer kernel and quantizer take strides; skip the copies.
         if q.stride(-1) != 1 or k.stride(-1) != 1 or v.stride(-1) != 1:

--- a/_tri_fwd.py
+++ b/_tri_fwd.py
@@ -8,7 +8,10 @@ the pointer twin for older arches, where Triton's descriptor emulation costs
 import torch
 import triton
 import triton.language as tl
-from triton.tools.tensor_descriptor import TensorDescriptor
+try:
+    from triton.tools.tensor_descriptor import TensorDescriptor
+except ModuleNotFoundError:
+    TensorDescriptor = None
 
 from ._preprocess import prepare
 
@@ -328,6 +331,8 @@ def sol_attn(
     if use_tma:
         q, k, v = q.contiguous(), k.contiguous(), v.contiguous()
         q, k, v, tokens, padded = _pad_to_blocks(q, k, v, BLOCK)
+        if TensorDescriptor is None:
+            raise RuntimeError("TensorDescriptor is unavailable for the TMA path.")
     else:
         # Pointer kernels mask ragged tails and take strides, so skip the
         # contiguous+pad copies (a multi-GB transient at video lengths).


### PR DESCRIPTION
fix TensorDescriptor import for pre-SM90 GPUs
avoid importing TensorDescriptor unconditionally.

on pre-SM90 GPUs, Sol-Attn always uses the pointer kernel (_forward_ptr) and never requires TensorDescriptor. However, importing TensorDescriptor at module load time caused an immediate ModuleNotFoundError on Triton builds where triton.tools.tensor_descriptor is unavailable.

tested on a 3060, i don't know if it will work in 20xx or 10xxx cards