### PR TITLE
Fix pooled kc/vc batch stride, skip the TMA path on ROCm

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -478,7 +478,8 @@ class SolAttnPatch(io.ComfyNode):
                                          "VRAM matches the pointer path. Off by default "
                                          "because it has not measured faster on any tested "
                                          "GPU. Requires SM90+ and Triton 3.3+; ignored "
-                                         "otherwise. 'verbose' logs the path used."),
+                                         "otherwise, including on AMD. "
+                                         "'verbose' logs the path used."),
                 io.String.Input("tau_profile", optional=True, force_input=True,
                                 tooltip="Per-block tau, overriding the base value. "
                                         "'blocks=tau' entries separated by ';' or newlines, "

--- a/_preprocess.py
+++ b/_preprocess.py
@@ -35,7 +35,7 @@ def _reduce_kc_kernel(
     T,
     s_b, s_t, s_h,  # k strides; last dim contiguous
     H: tl.constexpr,
-    N: tl.constexpr,
+    NPAD: tl.constexpr,  # padded block count: the batch stride of kc
     D: tl.constexpr,
     BLOCK: tl.constexpr,
     TILE_D: tl.constexpr,
@@ -56,7 +56,7 @@ def _reduce_kc_kernel(
     )
     summary = tl.sum(values, axis=0) / block_len
     tl.store(
-        kc + ((batch * N + block) * H + head) * D + offsets,
+        kc + ((batch * NPAD + block) * H + head) * D + offsets,
         summary,
         mask=offsets < D,
     )
@@ -77,7 +77,7 @@ def _reduce_vc_kernel(
     T,
     s_b, s_t, s_h,
     H: tl.constexpr,
-    N: tl.constexpr,
+    NPAD: tl.constexpr,  # padded block count: the batch stride of vc
     D: tl.constexpr,
     BLOCK: tl.constexpr,
     TILE_D: tl.constexpr,
@@ -97,7 +97,7 @@ def _reduce_vc_kernel(
     )
     summary = tl.sum(values, axis=0)
     tl.store(
-        vc + ((batch * N + block) * H + head) * D + offsets,
+        vc + ((batch * NPAD + block) * H + head) * D + offsets,
         summary,
         mask=offsets < D,
     )
@@ -182,7 +182,7 @@ def _reduce_kv(
         tokens,
         k.stride(0), k.stride(1), k.stride(2),
         heads,
-        blocks,
+        blocks_padded,
         head_dim,
         BLOCK_SIZE,
         tile_d,
@@ -193,7 +193,7 @@ def _reduce_kv(
         tokens,
         v.stride(0), v.stride(1), v.stride(2),
         heads,
-        blocks,
+        blocks_padded,
         head_dim,
         BLOCK_SIZE,
         tile_d,

--- a/_tri_fwd.py
+++ b/_tri_fwd.py
@@ -19,10 +19,21 @@ from ._autotune_log import AUTOTUNE_EXTRAS as _AUTOTUNE_EXTRAS, wrap as _wrap_au
 from ._preprocess import prepare
 
 _logged_no_descriptor = False
+_logged_hip = False
+
+IS_HIP = torch.version.hip is not None
 
 
 def _has_tma(device):
     # TensorDescriptor arrived in Triton 3.3; older installs run the pointer twin.
+    # ROCm reports its gfx arch through get_device_capability, which clears the
+    # SM90 test below although no AMD part has TMA.
+    if IS_HIP:
+        global _logged_hip
+        if not _logged_hip:
+            _logged_hip = True
+            logging.info("[sol_attn] ROCm has no TMA; using the pointer kernels.")
+        return False
     if torch.cuda.get_device_capability(device)[0] < 9:
         return False
     if TensorDescriptor is None:

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,9 @@ Triton kernels are compiled on first use, so the first run will be slower.
 Use `start_percent`, `end_percent`, and `tau` to balance generation quality and
 speed.
 
+AMD GPUs run through ROCm/HIP Triton. TMA is NVIDIA-only hardware, so the
+descriptor path is skipped on AMD and the pointer kernels are used instead.
+
 ## Examples
 
 ### Test output


### PR DESCRIPTION
#8 landed the `libdevice.round` lowering. Two changes, the first not AMD-specific.

`_reduce_kv` batch stride. It passed `blocks` to the reduction kernels as the kc/vc batch stride, but those tensors are allocated and read with `blocks_padded`. Any batch > 1 with `blocks % 64 != 0` routed on the wrong summaries - cosine similarity 0.798 --> 0.983 at B=2, T=512. Hidden until now because video runs are batch 1 and 4096+ tokens is already aligned.

`_has_tma` on ROCm. ROCm reports the gfx arch through `get_device_capability`, so AMD parts clear the SM90 test and take the descriptor path. Not fatal - Triton 3.8 lowers TensorDescriptor to ordinary loads on ROCm and the output is correct - but there is no TMA hardware behind it, so it pays the block-pad copies for nothing. Now gated on `torch.version.hip`; the older-Triton fallback is unchanged.

Tested on gfx1200, torch 2.12 / ROCm 7.15, Triton 3.8: bf16 and int8 against an fp32 reference across ragged tails, batching, strided qkv views, sinks and tau=-10 exactness, under both a single config and the full autotune sweep; plus MiniMax-H3 end to end in ComfyUI at 12134 tokens x 56 heads.