### PR TITLE
Improve README with official Sol-Attn links and citation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,22 +1,46 @@
-## Experimental Sol-Attn implementation for ComfyUI
+<h1 align="center">ComfyUI-SolAttn</h1>
 
-work in progress
+<h4 align="center">
+  Experimental Triton implementation of Sol-Attn for ComfyUI
+</h4>
 
-https://owen718.github.io/pubs/43-2026-arxiv-solattn/
+<p align="center">
+  <a href="https://arxiv.org/abs/2607.24027"><img src="https://img.shields.io/badge/📄_Paper-arXiv-b31b1b?style=flat-square" alt="Paper"/></a>
+  <a href="https://github.com/NVlabs/Sana/tree/sol-engine/techniques/sparse_backends/sol_attn"><img src="https://img.shields.io/badge/💻_Code-Sol--Attn-76b900?style=flat-square" alt="Code"/></a>
+  <a href="https://nvlabs.github.io/Sana/Sol-Attn/"><img src="https://img.shields.io/badge/🌐_Project-Page-blue?style=flat-square" alt="Project Page"/></a>
+</p>
 
-Only tested on 4090 and 5090 with MiniMax H3. Uses triton so first run will be slower.
+---
 
-Balance the quality/speed with start/end percent and tau.
+## Overview
 
-Tests:
+[Sol-Attn](https://arxiv.org/abs/2607.24027) is a training-free sparse attention
+method for accelerating image and video generation. This community extension
+integrates a Triton implementation of Sol-Attn into ComfyUI.
+
+> [!NOTE]
+> This project is a work in progress. It has currently been tested on RTX 4090
+> and RTX 5090 GPUs with MiniMax H3.
+
+## Usage notes
+
+Triton kernels are compiled on first use, so the first run will be slower.
+
+Use `start_percent`, `end_percent`, and `tau` to balance generation quality and
+speed.
+
+## Examples
+
+### Test output
 
 https://github.com/user-attachments/assets/8d9ed820-0417-4d68-9d1c-5199534bed3b
 
+### SageAttention vs. Sol-Attn
 
 <table>
 <tr>
-<td align="center"><b>Sageattn</b></td>
-<td align="center"><b>Sol-attn</b></td>
+<td align="center"><b>SageAttention</b></td>
+<td align="center"><b>Sol-Attn</b></td>
 </tr>
 <tr>
 <td width="50%">
@@ -28,5 +52,17 @@ https://github.com/user-attachments/assets/8d9ed820-0417-4d68-9d1c-5199534bed3b
 </tr>
 </table>
 
+<img width="482" height="500" alt="Sol-Attn example result" src="https://github.com/user-attachments/assets/27ae9886-aa3e-4470-a507-3a7c52b24be5" />
 
-<img width="482" height="500" alt="image" src="https://github.com/user-attachments/assets/27ae9886-aa3e-4470-a507-3a7c52b24be5" />
+## Citation
+
+If you find Sol-Attn useful in your work, please cite the paper:
+
+```bibtex
+@article{li2026solattn,
+  title={Sol-Attn: Accelerating Video Generation Inference via On-the-Fly Attention Sparsification},
+  author={Li, Haopeng and Li, Yitong and Chen, Junsong and Ye, Tian and Liu, Haozhe and Yu, Jincheng and Wang, Duomin and Zhang, Ruihua and Xie, Zeke and Xie, Enze and Han, Song},
+  journal={arXiv preprint arXiv:2607.24027},
+  year={2026}
+}
+```


### PR DESCRIPTION
## Summary

- add badges linking to the official Sol-Attn paper, code, and project page
- remove the third-party paper summary link and point readers to the primary sources
- organize the existing hardware, usage, and example information into clearer sections
- add the official Sol-Attn BibTeX citation

## Motivation

Thank you for building and sharing this Triton extension of Sol-Attn for ComfyUI. We sincerely appreciate the work you have put into making Sol-Attn accessible to the ComfyUI community, and it is wonderful to see the method receiving attention and thoughtful extensions from the community.

This documentation-only update makes the project easier to navigate while preserving the implementation notes and visual comparisons already provided by the repository.

## Validation

- verified the Paper, Code, and Project Page links
- reviewed the Markdown structure and HTML media elements
- confirmed that this PR changes only `readme.md`
