### PR TITLE
Fix loading without Triton

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -20,9 +20,8 @@ from comfy.ldm.modules.attention import (
 from comfy.patcher_extension import CallbacksMP
 from comfy_api.latest import ComfyExtension, io
 
-from ._autotune_log import set_verbose as _set_autotune_verbose
-
 try:
+    from ._autotune_log import set_verbose as _set_autotune_verbose
     from ._tri_fwd import sol_attn as _sol_attn_kernel, _has_tma
     _IMPORT_ERROR = None
 except Exception as exc:  # triton / torch version issues
@@ -456,7 +455,9 @@ class SolAttnPatch(io.ComfyNode):
                 morton_curve, dense_blocks, verbose,
                 use_tma=False, int8_pv=True) -> io.NodeOutput:
         if _sol_attn_kernel is None:
-            raise RuntimeError(f"Sol-Attn kernel unavailable: {_IMPORT_ERROR}")
+            _log_once(("kernel_unavailable", str(_IMPORT_ERROR)),
+                      f"kernel unavailable; passing MODEL through unchanged: {_IMPORT_ERROR}")
+            return io.NodeOutput(model)
         if int8_qk and _sol_attn_int8_kernel is None:
             raise RuntimeError(f"Sol-Attn INT8 kernel unavailable: {_INT8_IMPORT_ERROR}")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+triton>=3.3; platform_system == "Linux" and platform_machine == "x86_64"


### PR DESCRIPTION
## Summary

- include the autotune helper in the optional Triton import path
- keep the custom node registered when Triton is unavailable
- pass the input MODEL through unchanged instead of raising locally
- install Triton 3.3+ on supported Linux x86_64 environments while skipping unsupported platforms

## Root cause

The autotune helper imported Triton before the existing guarded kernel import, so environments without Triton could not load the custom node. The execution path also raised when the kernel was unavailable, and the repository had no dependency manifest for the remote environment.

The CUDA/Triton execution path is unchanged when the backend imports successfully.

## Validation

- compiled `__init__.py`
- imported the extension in a macOS ARM64 ComfyUI venv without Triton
- executed `SolAttnPatch` and verified the output preserves the exact input MODEL object
- parsed the requirement marker and verified it does not apply on macOS ARM64
- audited `requirements.txt` with uv and ran `uv pip check`
- ran `git diff --check`
